### PR TITLE
fix(module-management): enforce authorization and correct lifecycle semantics

### DIFF
--- a/src/main/kotlin/com/rpgportugal/orthanc/kt/discord/application/manager/impl/ModuleStateManagerImpl.kt
+++ b/src/main/kotlin/com/rpgportugal/orthanc/kt/discord/application/manager/impl/ModuleStateManagerImpl.kt
@@ -23,9 +23,9 @@ class ModuleStateManagerImpl(
         }
 
         return stateManager.accessState { runningMods ->
-            stopInternal(moduleName, runningMods)?.let { error ->
-                log.error("start - Failed to stop module: {}", error.message)
-                return@accessState error
+            if (runningMods.containsKey(moduleName)) {
+                log.error("start - module {} is already running", moduleName)
+                return@accessState ModuleStateError.ModuleAlreadyRunning(moduleName)
             }
 
             when (val result = module.start(this)) {
@@ -45,6 +45,11 @@ class ModuleStateManagerImpl(
     }
 
     override fun stop(moduleName: String): DomainError? {
+        if (!botModules.containsKey(moduleName)) {
+            log.error("stop - No such module: {}", moduleName)
+            return ModuleStateError.ModuleDoesNotExist(moduleName)
+        }
+
         return stateManager.accessState { runningMods ->
             stopInternal(moduleName, runningMods)
         }
@@ -66,19 +71,22 @@ class ModuleStateManagerImpl(
     }
 
     private fun stopInternal(moduleName: String, runningMods: MutableMap<String, TryCloseable>): DomainError? {
-        if (!runningMods.containsKey(moduleName)) {
+        val closeable = runningMods[moduleName]
+        if (closeable == null) {
             log.error("stop - module {} is not running", moduleName)
             return ModuleStateError.ModuleNotRunning(moduleName)
         }
-        return when (val result = runningMods.remove(moduleName)) {
-            is TryCloseable -> result.tryClose()?.also {
-                log.error("stop - module {} failed to stop: {}", moduleName, it.message)
-            }
-            else -> {
-                log.info("stop - Module {} not found", moduleName)
-                null
-            }
+
+        val error = closeable.tryClose()
+        if (error != null) {
+            log.error("stop - module {} failed to stop: {}", moduleName, error.message)
+            return error
         }
+
+        runningMods.remove(moduleName)
+        log.info("stop - module {} stopped", moduleName)
+
+        return null
     }
 
     private class StateManager(private val moduleStateManager: ModuleStateManager, allModules: Map<String, BotModule>) :

--- a/src/main/kotlin/com/rpgportugal/orthanc/kt/discord/modules/management/ModuleStateManagementListenerAdapter.kt
+++ b/src/main/kotlin/com/rpgportugal/orthanc/kt/discord/modules/management/ModuleStateManagementListenerAdapter.kt
@@ -11,7 +11,6 @@ import com.rpgportugal.orthanc.kt.logging.Loggable
 import com.rpgportugal.orthanc.kt.logging.log
 import com.rpgportugal.orthanc.kt.persistence.dto.module.ModuleStateManagementConfiguration
 import net.dv8tion.jda.api.JDA
-import net.dv8tion.jda.api.entities.UserSnowflake
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 class ModuleStateManagementListenerAdapter(
@@ -33,8 +32,13 @@ class ModuleStateManagementListenerAdapter(
     }
 
     override fun onMessageReceived(event: MessageReceivedEvent) {
+        if (!event.isFromGuild) {
+            return
+        }
+
         val msg = event.message
         val cmd = msg.contentStripped.lowercase().split(' ')
+
         if (cmd.size != 2) {
             return
         }
@@ -42,22 +46,14 @@ class ModuleStateManagementListenerAdapter(
         val command = cmd[0]
         val moduleName = cmd[1]
 
-        if (moduleName == this.evokerModuleName) {
-            log.warn("cannot evoke state commands on self: {}", moduleName)
-            return
-        }
-
-        val (error, operation) = when (command) {
-            "\$start" -> moduleStateManager.start(moduleName) to AppManagementOperation.Start
-            "\$stop" -> moduleStateManager.stop(moduleName) to AppManagementOperation.Stop
-            "\$check" -> moduleStateManager.failIfNotRunning(moduleName) to AppManagementOperation.Check
+        val operation = when (command) {
+            "\$start" -> AppManagementOperation.Start
+            "\$stop" -> AppManagementOperation.Stop
+            "\$check" -> AppManagementOperation.Check
             else -> return
         }
 
-        val member =
-            msg.guild
-                .getMember(UserSnowflake.fromId(msg.author.idLong))
-                ?: return
+        val member = event.member ?: return
 
         when (val res = permissionManager.hasPermission(Permission.ManageModuleState, member)) {
             is Either.Right -> {
@@ -69,8 +65,19 @@ class ModuleStateManagementListenerAdapter(
 
             is Either.Left -> {
                 log.error("onMessageReceived - failed to retrieve permissions - {}", res.value.message)
-                throw Exception(res.value.message)
+                return
             }
+        }
+
+        if (moduleName == this.evokerModuleName) {
+            log.warn("cannot evoke state commands on self: {}", moduleName)
+            return
+        }
+
+        val error = when (operation) {
+            AppManagementOperation.Start -> moduleStateManager.start(moduleName)
+            AppManagementOperation.Stop -> moduleStateManager.stop(moduleName)
+            AppManagementOperation.Check -> moduleStateManager.failIfNotRunning(moduleName)
         }
 
         val text =

--- a/src/main/kotlin/com/rpgportugal/orthanc/kt/error/ModuleStateError.kt
+++ b/src/main/kotlin/com/rpgportugal/orthanc/kt/error/ModuleStateError.kt
@@ -6,6 +6,11 @@ interface ModuleStateError : DomainError {
         override val message: String = "module $moduleName is not running",
     ) : ModuleStateError
 
+    data class ModuleAlreadyRunning(
+        val moduleName: String,
+        override val message: String = "module $moduleName is already running",
+    ) : ModuleStateError
+
     data class ModuleDoesNotExist(
         val moduleName: String,
         override val message: String = "module $moduleName does not exist",


### PR DESCRIPTION
Fix module management authorization and start/stop behavior.

* Test for `Permission.ManageModuleState` before calling any module state operation.
* Make `start()` _only_ start stopped modules, instead of also restarting running ones.
* Return `ModuleAlreadyRunning` when starting an active module.
* Make `stop()` distinguish missing modules from stopped modules.
* Keep modules in `runningMods` if `tryClose()` fails.


Start/stop behavior:
* `start(stopped)` -> starts
* `start(running)` -> `ModuleAlreadyRunning`
* `start(missing)` -> `ModuleDoesNotExist`
* `stop(running)` -> stops
* `stop(stopped)` -> `ModuleNotRunning`
* `stop(missing)` -> `ModuleDoesNotExist`

Since `start()` no longer doubles as an implicit restart, if restart behavior is needed, it's probably better as a separate operation.